### PR TITLE
Add ability to use propertyResovlers in App Launcher SPEL

### DIFF
--- a/src/main/java/org/jasig/portlet/widget/service/PropertyResolverAccessor.java
+++ b/src/main/java/org/jasig/portlet/widget/service/PropertyResolverAccessor.java
@@ -18,64 +18,38 @@
  */
 package org.jasig.portlet.widget.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.convert.Property;
 import org.springframework.core.env.PropertyResolver;
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
 
-
 /**
- * @author Josh Helmer, jhelmer@unicon.net
- *
- * Property accessor that tries to log an error and provide a default value
- * if a property can not be found.
- *
- * Limitation:  the accessor only gets access to the leaf property name.  If
- * you have a property like:  user.login.id, this will only be able to print
- * "${id}"  In the future need to revisit to try and find a more flexible
- * mechanism for handling without just throwing an exception.
+ * Created by andrew on 7/25/16.
  */
-public class DefaultPropertyAccessor implements PropertyAccessor {
-    protected Logger logger = LoggerFactory.getLogger(getClass());
-    private String leading;
-    private String trailing;
-
-    public DefaultPropertyAccessor(final String leading, final String trailing) {
-        this.leading = leading;
-        this.trailing = trailing;
-    }
-
-
+public class PropertyResolverAccessor implements PropertyAccessor {
     @Override
     public Class[] getSpecificTargetClasses() {
-        return new Class[] { Object.class };
+        return new Class[] { PropertyResolver.class };
     }
-
 
     @Override
     public boolean canRead(EvaluationContext evaluationContext, Object o, String s) throws AccessException {
-        return true;
+        return o != null;
     }
-
 
     @Override
     public TypedValue read(EvaluationContext evaluationContext, Object o, String s) throws AccessException {
-        logger.error("Property '" + s + "' not found!");
-        return new TypedValue(leading + s + trailing);
+        PropertyResolver pr = (PropertyResolver) o;
+        return new TypedValue(pr.getProperty(s)); // Returns TypedValue(null), allowing defaults to be processed
     }
-
 
     @Override
     public boolean canWrite(EvaluationContext evaluationContext, Object o, String s) throws AccessException {
         return false;
     }
 
-
-    @Override
-    public void write(EvaluationContext evaluationContext, Object o, String s, Object o2) throws AccessException {
+    public void write(EvaluationContext evaluationContext, Object o, String s, Object o1) throws AccessException {
+        //Unreachable
     }
 }

--- a/src/main/java/org/jasig/portlet/widget/service/SpringELProcessor.java
+++ b/src/main/java/org/jasig/portlet/widget/service/SpringELProcessor.java
@@ -30,9 +30,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MapAccessor;
+import org.springframework.core.env.PropertyResolver;
 import org.springframework.expression.BeanResolver;
 import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.TemplateParserContext;
@@ -54,6 +56,14 @@ public class SpringELProcessor implements IExpressionProcessor, BeanFactoryAware
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
     private BeanResolver beanResolver;
+
+    private PropertyResolver propertyResolver;
+
+    @Autowired
+    public void setPropertyResolver(PropertyResolver propertyResolver) {
+        this.propertyResolver = propertyResolver;
+    }
+
     private Properties properties;
 
 
@@ -85,6 +95,10 @@ public class SpringELProcessor implements IExpressionProcessor, BeanFactoryAware
         Map<String, Object> context = getContext(request);
 
         StandardEvaluationContext sec = new StandardEvaluationContext(context);
+
+        sec.setVariable("systemProperties", propertyResolver);
+
+        sec.addPropertyAccessor(new PropertyResolverAccessor());
         sec.addPropertyAccessor(new MapAccessor());
         sec.addPropertyAccessor(new ReflectivePropertyAccessor());
         sec.addPropertyAccessor(new DefaultPropertyAccessor(

--- a/src/main/java/org/springframework/context/support/ExtendedPropertySourcesPlaceholderConfigurer.java
+++ b/src/main/java/org/springframework/context/support/ExtendedPropertySourcesPlaceholderConfigurer.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.springframework.context.support;
+
+import java.io.IOException;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanInitializationException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertyResolver;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.PropertySourcesPropertyResolver;
+
+
+/**
+ * @author Josh Helmer, jhelmer@unicon.net
+ */
+public class ExtendedPropertySourcesPlaceholderConfigurer extends PropertySourcesPlaceholderConfigurer {
+    public static final String EXTENDED_PROPERTIES_SOURCE = "extendedPropertiesSource";
+
+    private PropertyResolver propertyResolver;
+
+
+    /**
+     * Override the postProcessing.  The default PropertySourcesPlaceholderConfigurer does not inject
+     * local properties into the Environment object.  It builds a local list of properties files and
+     * then uses a transient Resolver to resolve the @Value annotations.   That means that you are
+     * unable to get to "local" properties (eg. portal.properties) after bean post-processing has
+     * completed unless you are going to re-parse those file.  This is similar to what
+     * PropertiesManager does, but it uses all the property files configured, not just portal.properties.
+     *
+     * If we upgrade to spring 4, there are better/more efficient solutions available.  I'm not aware
+     * of better solutions for spring 3.x.
+     *
+     * @param beanFactory the bean factory
+     * @throws BeansException if an error occurs while loading properties or wiring up beans
+     */
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        if (propertyResolver == null) {
+            try {
+                MutablePropertySources sources = new MutablePropertySources();
+                PropertySource<?> localPropertySource = new PropertiesPropertySource(EXTENDED_PROPERTIES_SOURCE, mergeProperties());
+                sources.addLast(localPropertySource);
+
+                propertyResolver = new PropertySourcesPropertyResolver(sources);
+
+            } catch (IOException e) {
+                throw new BeanInitializationException("Could not load properties", e);
+            }
+        }
+
+        super.postProcessBeanFactory(beanFactory);
+    }
+
+
+    /**
+     * Get a property resolver that can read local properties.
+     *
+     * @return a property resolver that can be used to dynamically read the merged property
+     * values configured in applicationContext.xml
+     */
+    public PropertyResolver getPropertyResolver() {
+        return propertyResolver;
+    }
+}

--- a/src/main/java/org/springframework/context/support/ExtendedPropertySourcesPlaceholderConfigurer.java
+++ b/src/main/java/org/springframework/context/support/ExtendedPropertySourcesPlaceholderConfigurer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.core.env.MutablePropertySources;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertyResolver;
@@ -32,7 +33,13 @@ import org.springframework.core.env.PropertySourcesPropertyResolver;
 
 /**
  * @author Josh Helmer, jhelmer@unicon.net
+ *
+ * Aug 05 2016: This has been included (copied from uPortal) temporarily. The goal
+ * for the near future is to have this particular class included as an external
+ * dependency once it is split out from uPortal.
+ *
  */
+@Deprecated
 public class ExtendedPropertySourcesPlaceholderConfigurer extends PropertySourcesPlaceholderConfigurer {
     public static final String EXTENDED_PROPERTIES_SOURCE = "extendedPropertiesSource";
 

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -28,6 +28,50 @@
     http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd
 	http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang-2.5.xsd">
 
+    <!-- Configurable properties -->
+    <bean id="primaryPropertyPlaceholderConfigurer" class="org.springframework.context.support.ExtendedPropertySourcesPlaceholderConfigurer">
+      <property name="locations">
+        <list>
+          <value>classpath:/properties/rdbm.properties</value>
+          <value>classpath:/properties/security.properties</value>
+          <value>classpath:/properties/portal.properties</value>
+          <value>classpath:/properties/ccc/webresources-aws-s3.properties</value>
+            <!-- 
+             |  The following files optionally allow deployers to set or override many JasigWidgetPortlets
+             |  configuration settings in a outside the control of the build/deploy cycle, SCM, 
+             |  and Tomcat.
+             |
+             |  Reasons for choosing that may include:
+             |    - Desire to keep sensitive information out of your Git repository
+             |    - Ability to change some common settings without a full build and deploy cycle
+             |    - Building a WAR/EAR that is environment-independent.
+             |
+             |  Any property defined in the above files that is referenced in the Spring context 
+             |  may be overridden in one (or both) of these files.
+             |
+             |  The default location for overrides is ${CATALINA_HOME}/portal/overrides.properties;  
+             |  you can use a custom location by specifying PORTAL_HOME as a JVM startup argument 
+             |  or as an environment variable.
+             |
+             |  The first two files (overrides.properties) are intended to contain properties,
+             |  such as database secrets, that are shared with portlets (they read those property
+             |  files also).  The latter two files
+             |  (JasigWidgetPortlets_overrides.properties) are for properties
+             |  that are specific to JasigWidgetPortlets (portlets should not read
+             |  these files).
+             +-->
+
+          <value>file:${CATALINA_HOME}/portal/overrides.properties</value>
+          <value>file:${PORTAL_HOME}/overrides.properties</value>
+          <value>file:${CATALINA_HOME}/portal/JasigWidgetPortlets_overrides.properties</value>
+          <value>file:${PORTAL_HOME}/JasigWidgetPortlets_overrides.properties</value>
+        </list>
+      </property>
+      <property name="ignoreResourceNotFound" value="true" />
+      <property name="ignoreUnresolvablePlaceholders" value="true"/>
+    </bean>
+
+    <bean id="propertyResolver" factory-bean="primaryPropertyPlaceholderConfigurer" factory-method="getPropertyResolver"/>
 	<!--
 	 | Message source for this context, loaded from localized "messages_xx" files
 	 +-->


### PR DESCRIPTION
This exposes an additional variable (as `#systemProperties`) that contains whichever property resolver is injected (configurable via Spring, of course).

https://issues.jasig.org/browse/WIDGPT-67