### PR TITLE
chore: migrate to org.dom4j package version 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,9 +110,9 @@
                 <version>2.6</version>
             </dependency>
            <dependency>
-               <groupId>dom4j</groupId>
+               <groupId>org.dom4j</groupId>
                <artifactId>dom4j</artifactId>
-               <version>1.6.1</version>
+               <version>2.1.1</version>
            </dependency>
             <dependency>
                 <groupId>javax.portlet</groupId>
@@ -415,7 +415,7 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
-           <groupId>dom4j</groupId>
+           <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
release notes for the v2 major are listed here: https://github.com/dom4j/dom4j/releases/tag/version-2.0.0, https://github.com/dom4j/dom4j/releases/tag/version-2.1.0, and https://github.com/dom4j/dom4j/releases/tag/version-2.1.1

Mainly it now requires Java 8 or higher.